### PR TITLE
Docker install example for local mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Lifecycle Configurations (LCCs) provide a mechanism to customize SageMaker Studi
 ### Common scripts
 These scripts will work with both SageMaker JupyterLab and SageMaker Code Editor apps. Note that if you want the script to be available across both apps, you will need to set them as an LCC script for both apps.
 - [ebs-s3-backup-restore](common-scripts/ebs-s3-backup-restore) - This script backs up content in a user space's EBS volume (user's home directory under `/home/sagemaker-user`) to an S3 bucket that's specified on the script, optionally on a schedule. If the user profile is tagged with a `SM_EBS_RESTORE_TIMESTAMP` tag, then the script will restore the backup files into the user's home directory, in addition to backups.
+- [install-docker-local-mode](common-scripts/install-docker-local-mode) - This script installs the Docker CLI to enable using [SageMaker Local Mode](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-updated-local.html) within Studio.
 
 ## Developing LLCs for SageMaker Studio applications
 For best practices, please check [DEVELOPMENT](DEVELOPMENT.md).
@@ -33,3 +34,4 @@ This project is licensed under the [MIT-0 License](LICENSE).
 [Giuseppe A. Porcelli](https://www.linkedin.com/in/giuporcelli/) - Principal, ML Specialist Solutions Architect - Amazon SageMaker
 <br />Spencer Ng - Software Development Engineer - Amazon SageMaker
 <br />Durga Sury - Senior ML Specialist Solutions Architect - Amazon SageMaker
+<br />Alex Thewsey - Senior ML Specialist Solutions Architect - AWS

--- a/common-scripts/install-docker-local-mode/README.md
+++ b/common-scripts/install-docker-local-mode/README.md
@@ -1,0 +1,54 @@
+# Install Docker and enable SageMaker Local Mode
+
+While running SageMaker jobs using on-demand compute is great for optimizing infrastructure consumption and tracking experiments, waiting for infrastructure start-up each time is not the fastest workflow for **debugging** custom training scripts and containers. There are multiple tools available to accelerate this process, including:
+
+1. [SageMaker Managed Warm Pools](https://docs.aws.amazon.com/sagemaker/latest/dg/train-warm-pools.html), which allows you to keep your instance(s) "warm" for a specified time-out period after a training job completes - and start new jobs on them in seconds rather than minutes.
+2. Using AWS Systems Manager to [remotely access](https://docs.aws.amazon.com/sagemaker/latest/dg/train-remote-debugging.html) running training containers (or even other SageMaker resources, using the [SageMaker SSH Helper toolkit](https://github.com/aws-samples/sagemaker-ssh-helper)) to use remote interactive debugging tools.
+3. **[SageMaker Local Mode](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-updated-local.html)**, which uses the [Docker CLI](https://docs.docker.com/engine/reference/run/) and [Docker Compose CLI](https://docs.docker.com/compose/reference/) to **emulate** (a subset of) SageMaker runtime features on your local notebook/machine using the same target container image.
+
+While [SageMaker Local Mode is now available in SageMaker Studio environments](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-updated-local.html), it requires some configuration to enable - which this sample demonstrates.
+
+
+## Pre-requisites
+
+### Enable Studio Docker Access
+
+As [noted in the developer guide](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-updated-local.html#studio-updated-local-enable), you'll first need to enable Docker access in your Studio Domain. See the developer guide for more configuration options:
+
+```sh
+aws --region $YOUR_REGION \
+    sagemaker update-domain --domain-id $YOUR_DOMAIN_ID \
+    --domain-settings-for-update '{"DockerSettings": {"EnableDockerAccess": "ENABLED"}}'
+```
+
+
+### Check your `sagemaker` SDK version
+
+Support for SageMaker Local Mode in Studio environments was [added in v2.203.0](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.md#v22030-2023-12-28), which at the time of writing is not yet reflected in the default SageMaker JupyterLab ([SageMaker Distribution v1.3](https://github.com/aws/sagemaker-distribution)) image.
+
+```python
+# To check your installed version:
+import sagemaker
+print(sagemaker.__version__)
+
+# To upgrade from within a notebook:
+%pip install --upgrade sagemaker
+```
+
+> ⚠️ If you're working in a notebook and already ran an `import` from `sagemaker`, you'll need to **restart the kernel** for this change to take effect.
+>
+> The provided LCC attempts to automate this upgrade on app start, but may miss some environments if you have custom kernels set up.
+
+
+## Set up the Lifecycle Configuration Script
+
+Use the commands in [on-start.sh](./on-start.sh) to create a LCC of type `JupyterLab` **OR** `CodeEditor`, and attach it to your Studio Domain and/or User Profile (See the general guidance in [this repository's root README](../../README.md) for more details on these steps, and debugging if things go wrong).
+
+The same script code should work for either JupyterLab and Code Editor spaces, but if you want to use both you'll need to create a separate SageMaker LCC for each type.
+
+
+## Verify your setup
+
+After (re)-starting your JupyterLab Space with the LCC attached, you should be able to run `docker --version` and/or `docker run --net sagemaker hello-world` from a terminal.
+
+From a Python notebook or terminal (re-check your `sagemaker` SDK version!), you should now be able to start [exploring Local Mode](https://sagemaker.readthedocs.io/en/stable/overview.html#local-mode). We tested with the `pytorch_script_mode_local_model_inference` and `amazon-sagemaker-local-mode/pytorch_script_mode_local_training_and_serving` samples from https://github.com/aws-samples/amazon-sagemaker-local-mode - where you can also find other examples.

--- a/common-scripts/install-docker-local-mode/on-start.sh
+++ b/common-scripts/install-docker-local-mode/on-start.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -ex
+
+# As per: https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository
+# Add Docker's official GPG key:
+sudo apt-get update
+sudo apt-get -y install ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+# Add the repository to Apt sources:
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+
+sudo apt-get -y install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+# SageMaker Python SDK introduced support for Local Mode in Studio at v2.203.0:
+pip install "sagemaker>=2.203.0,<3"


### PR DESCRIPTION
**Issue #, if available:** N/A

**Description of changes:**

Re-raising https://github.com/aws-samples/sagemaker-studio-lifecycle-config-examples/pull/43 as requested against this repo for new SageMaker Studio.

[SageMaker Local Mode](https://aws.amazon.com/blogs/machine-learning/use-the-amazon-sagemaker-local-mode-to-train-on-your-notebook-instance/) is now available within SMStudio to accelerate debugging workflows (yay!), but requires some [extra setup to enable](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-updated-local.html). This new script example attempts to walk customers easily through a persistent Docker CLI setup to enable Local Mode.

**Testing done:**

In addition to the testing for the original PR, re-tested on current SageMaker Distribution image in us-west-2 as of today and the setup is working fine.

<br/>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
