### PR TITLE
Fix for cron service not running by default in sm distribution 1.6 for JupyterLab

### DIFF
--- a/code-editor/auto-stop-idle/README.md
+++ b/code-editor/auto-stop-idle/README.md
@@ -70,7 +70,7 @@ sudo $CONDA_HOME/pip install -U -t $SOLUTION_DIR /var/tmp/sagemaker_code_editor_
 
 ### If you are using sagemaker distribution image <=1.5, add below additional changes in script.
 
-### Download the cron package from https://packages.ubuntu.com/jammy/amd64/cron/download 
+### Download the cron package from [repository](https://packages.ubuntu.com/jammy/amd64/cron/download). 
 ```
 curl -LO http://mirrors.kernel.org/ubuntu/pool/main/c/cron/cron_3.0pl1-137ubuntu3_amd64.deb
 ```

--- a/code-editor/auto-stop-idle/README.md
+++ b/code-editor/auto-stop-idle/README.md
@@ -52,7 +52,7 @@ aws sagemaker update-domain \
 ```
 ## Steps for installing in Internet-Free VPC environments:
 
-* Note : You domain execution role must have privileges to download the packages from your s3 bucket where the below packages are uploaded. 
+* Note : Your domain execution role must have privileges to download the packages from your s3 bucket where the below packages are uploaded. 
 
 1. Downloading autostop idle Python package and upload to s3 bucket.
 ```
@@ -70,7 +70,7 @@ aws s3 cp <YOUR-S3-BUCKET-PATH>/sagemaker_code_editor_auto_shut_down-$ASI_VERSIO
 sudo $CONDA_HOME/pip install -U -t $SOLUTION_DIR /var/tmp/sagemaker_code_editor_auto_shut_down-$ASI_VERSION.tar.gz
 ```
 
-3. If you are using sagemaker distribution image <=1.5, add below additional changes in script.
+3. If you are using sagemaker distribution image version `1.5` and below, add below additional changes in script.
 
 - Download the cron package from [repository](https://packages.ubuntu.com/jammy/amd64/cron/download). 
 ```

--- a/code-editor/auto-stop-idle/README.md
+++ b/code-editor/auto-stop-idle/README.md
@@ -52,6 +52,8 @@ aws sagemaker update-domain \
 ```
 ## Steps for installing in Internet-Free VPC environments:
 
+* Note : You domain execution role must have privileges to download the packages from your s3 bucket where the below packages are uploaded. 
+
 ### Downloading autostop idle Python package and upload to s3 bucket.
 ```
 ASI_VERSION=0.3.0

--- a/code-editor/auto-stop-idle/README.md
+++ b/code-editor/auto-stop-idle/README.md
@@ -54,7 +54,7 @@ aws sagemaker update-domain \
 
 * Note : You domain execution role must have privileges to download the packages from your s3 bucket where the below packages are uploaded. 
 
-### Downloading autostop idle Python package and upload to s3 bucket.
+1. Downloading autostop idle Python package and upload to s3 bucket.
 ```
 ASI_VERSION=0.3.0
 PYTHON_PACKAGE=sagemaker_code_editor_auto_shut_down-$ASI_VERSION.tar.gz
@@ -63,25 +63,27 @@ curl -LO https://github.com/aws-samples/sagemaker-studio-apps-lifecycle-config-e
 aws s3 cp sagemaker_code_editor_auto_shut_down-$ASI_VERSION.tar.gz <YOUR-S3-BUCKET-PATH> 
 ```
 
-### Edit the on-start.sh file and replace "45 and 46" with:
+2. Edit the on-start.sh file and replace "45 and 46" with:
 
 ```
 aws s3 cp <YOUR-S3-BUCKET-PATH>/sagemaker_code_editor_auto_shut_down-$ASI_VERSION.tar.gz /var/tmp/sagemaker_code_editor_auto_shut_down-$ASI_VERSION.tar.gz
 sudo $CONDA_HOME/pip install -U -t $SOLUTION_DIR /var/tmp/sagemaker_code_editor_auto_shut_down-$ASI_VERSION.tar.gz
 ```
 
-### If you are using sagemaker distribution image <=1.5, add below additional changes in script.
+3. If you are using sagemaker distribution image <=1.5, add below additional changes in script.
 
-### Download the cron package from [repository](https://packages.ubuntu.com/jammy/amd64/cron/download). 
+- Download the cron package from [repository](https://packages.ubuntu.com/jammy/amd64/cron/download). 
 ```
 curl -LO http://mirrors.kernel.org/ubuntu/pool/main/c/cron/cron_3.0pl1-137ubuntu3_amd64.deb
 ```
-### Copy package to s3. 
+
+- Copy package to s3.
+  
 ```
 aws s3 cp cron_3.0pl1-137ubuntu3_amd64.deb <YOUR-S3-BUCKET-PATH>
 ```
 
-### Edit the on-start.sh file and replace line "33" with:
+- Edit the on-start.sh file and replace line "33" with:
 ```
 aws s3 cp  <YOUR-S3-BUCKET-PATH>/cron_3.0pl1-137ubuntu3_amd64.deb /tmp/cron_3.0pl1-137ubuntu3_amd64.deb
 sudo dpkg -i /tmp/cron_3.0pl1-137ubuntu3_amd64.deb

--- a/code-editor/auto-stop-idle/README.md
+++ b/code-editor/auto-stop-idle/README.md
@@ -50,6 +50,40 @@ aws sagemaker update-domain \
     }'
 
 ```
+# Steps for installing in Internet-Free VPC environments:
+
+## Downloading autostop idle Python package and upload to s3 bucket.
+```
+ASI_VERSION=0.3.0
+PYTHON_PACKAGE=sagemaker_code_editor_auto_shut_down-$ASI_VERSION.tar.gz
+echo "Downloading autostop idle Python package..."
+curl -LO https://github.com/aws-samples/sagemaker-studio-apps-lifecycle-config-examples/releases/download/v$ASI_VERSION/$PYTHON_PACKAGE
+aws s3 cp sagemaker_code_editor_auto_shut_down-$ASI_VERSION.tar.gz <YOUR-S3-BUCKET-PATH> 
+```
+
+## Edit the on-start.sh file and replace "45 and 46" with:
+
+```
+aws s3 cp <YOUR-S3-BUCKET-PATH>/sagemaker_code_editor_auto_shut_down-$ASI_VERSION.tar.gz /var/tmp/sagemaker_code_editor_auto_shut_down-$ASI_VERSION.tar.gz
+sudo $CONDA_HOME/pip install -U -t $SOLUTION_DIR /var/tmp/sagemaker_code_editor_auto_shut_down-$ASI_VERSION.tar.gz
+```
+
+## If you are using sagemaker distribution image <=1.5, add below additional changes in script.
+
+### Download the cron package from https://packages.ubuntu.com/jammy/amd64/cron/download 
+```
+curl -LO http://mirrors.kernel.org/ubuntu/pool/main/c/cron/cron_3.0pl1-137ubuntu3_amd64.deb
+```
+### Copy package to s3. 
+```
+aws s3 cp cron_3.0pl1-137ubuntu3_amd64.deb <YOUR-S3-BUCKET-PATH>
+```
+
+### Edit the on-start.sh file and replace line "33" with:
+```
+aws s3 cp  <YOUR-S3-BUCKET-PATH>/cron_3.0pl1-137ubuntu3_amd64.deb /tmp/cron_3.0pl1-137ubuntu3_amd64.deb
+sudo dpkg -i /tmp/cron_3.0pl1-137ubuntu3_amd64.deb
+```
 
 2. After successful domain update, navigate to Code Editor, and select the LCC when starting your Code Editor application.
 

--- a/code-editor/auto-stop-idle/README.md
+++ b/code-editor/auto-stop-idle/README.md
@@ -50,9 +50,9 @@ aws sagemaker update-domain \
     }'
 
 ```
-# Steps for installing in Internet-Free VPC environments:
+## Steps for installing in Internet-Free VPC environments:
 
-## Downloading autostop idle Python package and upload to s3 bucket.
+### Downloading autostop idle Python package and upload to s3 bucket.
 ```
 ASI_VERSION=0.3.0
 PYTHON_PACKAGE=sagemaker_code_editor_auto_shut_down-$ASI_VERSION.tar.gz
@@ -61,14 +61,14 @@ curl -LO https://github.com/aws-samples/sagemaker-studio-apps-lifecycle-config-e
 aws s3 cp sagemaker_code_editor_auto_shut_down-$ASI_VERSION.tar.gz <YOUR-S3-BUCKET-PATH> 
 ```
 
-## Edit the on-start.sh file and replace "45 and 46" with:
+### Edit the on-start.sh file and replace "45 and 46" with:
 
 ```
 aws s3 cp <YOUR-S3-BUCKET-PATH>/sagemaker_code_editor_auto_shut_down-$ASI_VERSION.tar.gz /var/tmp/sagemaker_code_editor_auto_shut_down-$ASI_VERSION.tar.gz
 sudo $CONDA_HOME/pip install -U -t $SOLUTION_DIR /var/tmp/sagemaker_code_editor_auto_shut_down-$ASI_VERSION.tar.gz
 ```
 
-## If you are using sagemaker distribution image <=1.5, add below additional changes in script.
+### If you are using sagemaker distribution image <=1.5, add below additional changes in script.
 
 ### Download the cron package from https://packages.ubuntu.com/jammy/amd64/cron/download 
 ```

--- a/code-editor/auto-stop-idle/README.md
+++ b/code-editor/auto-stop-idle/README.md
@@ -72,7 +72,8 @@ sudo $CONDA_HOME/pip install -U -t $SOLUTION_DIR /var/tmp/sagemaker_code_editor_
 
 3. If you are using sagemaker distribution image version `1.5` and below, add below additional changes in script.
 
-- Download the cron package from [repository](https://packages.ubuntu.com/jammy/amd64/cron/download). 
+- Download the cron package from [repository](https://packages.ubuntu.com/jammy/amd64/cron/download).
+  
 ```
 curl -LO http://mirrors.kernel.org/ubuntu/pool/main/c/cron/cron_3.0pl1-137ubuntu3_amd64.deb
 ```

--- a/code-editor/auto-stop-idle/README.md
+++ b/code-editor/auto-stop-idle/README.md
@@ -50,48 +50,10 @@ aws sagemaker update-domain \
     }'
 
 ```
-## Steps for installing in Internet-Free VPC environments:
-
-* Note : Your domain execution role must have privileges to download the packages from your s3 bucket where the below packages are uploaded. 
-
-1. Downloading autostop idle Python package and upload to s3 bucket.
-```
-ASI_VERSION=0.3.0
-PYTHON_PACKAGE=sagemaker_code_editor_auto_shut_down-$ASI_VERSION.tar.gz
-echo "Downloading autostop idle Python package..."
-curl -LO https://github.com/aws-samples/sagemaker-studio-apps-lifecycle-config-examples/releases/download/v$ASI_VERSION/$PYTHON_PACKAGE
-aws s3 cp sagemaker_code_editor_auto_shut_down-$ASI_VERSION.tar.gz <YOUR-S3-BUCKET-PATH> 
-```
-
-2. Edit the on-start.sh file and replace "45 and 46" with:
-
-```
-aws s3 cp <YOUR-S3-BUCKET-PATH>/sagemaker_code_editor_auto_shut_down-$ASI_VERSION.tar.gz /var/tmp/sagemaker_code_editor_auto_shut_down-$ASI_VERSION.tar.gz
-sudo $CONDA_HOME/pip install -U -t $SOLUTION_DIR /var/tmp/sagemaker_code_editor_auto_shut_down-$ASI_VERSION.tar.gz
-```
-
-3. If you are using sagemaker distribution image version `1.5` and below, add below additional changes in script.
-
-- Download the cron package from [repository](https://packages.ubuntu.com/jammy/amd64/cron/download).
-  
-```
-curl -LO http://mirrors.kernel.org/ubuntu/pool/main/c/cron/cron_3.0pl1-137ubuntu3_amd64.deb
-```
-
-- Copy package to s3.
-  
-```
-aws s3 cp cron_3.0pl1-137ubuntu3_amd64.deb <YOUR-S3-BUCKET-PATH>
-```
-
-- Edit the on-start.sh file and replace line "33" with:
-```
-aws s3 cp  <YOUR-S3-BUCKET-PATH>/cron_3.0pl1-137ubuntu3_amd64.deb /tmp/cron_3.0pl1-137ubuntu3_amd64.deb
-sudo dpkg -i /tmp/cron_3.0pl1-137ubuntu3_amd64.deb
-```
 
 2. After successful domain update, navigate to Code Editor, and select the LCC when starting your Code Editor application.
 
+Note: Currently this script does not support installtion in Internet Free VPC enviornments. 
 
 ### Definition of idleness
 

--- a/code-editor/auto-stop-idle/on-start.sh
+++ b/code-editor/auto-stop-idle/on-start.sh
@@ -33,7 +33,7 @@ if [ ! $? = 0 ] || [ ! "$status" = installed ]; then
 	sudo apt install cron
 else
 	echo "Package cron is already installed."
-    # Start/restart the service.
+        # Start/restart the service.
 	sudo service cron restart
 fi
 

--- a/code-editor/auto-stop-idle/on-start.sh
+++ b/code-editor/auto-stop-idle/on-start.sh
@@ -33,7 +33,7 @@ if [ ! $? = 0 ] || [ ! "$status" = installed ]; then
 	sudo apt install cron
 else
 	echo "Package cron is already installed."
-    # start/restart the service.
+    # Start/restart the service.
 	sudo service cron restart
 fi
 

--- a/jupyterlab/auto-stop-idle/README.md
+++ b/jupyterlab/auto-stop-idle/README.md
@@ -98,7 +98,7 @@ Following are the instructions on how to modify the lifecycle configuration to s
     aws s3 cp $PYTHON_PACKAGE s3://<your_bucket_name>/<your_prefix>/
     ```
 
-3. Edit the `on-start.sh` file and replace line 45 with:
+3. Edit the `on-start.sh` file and replace line 56 with:
 
     ```
     sudo aws s3 cp s3://<your_bucket_name>/<your_prefix>/$PYTHON_PACKAGE /var/tmp/

--- a/jupyterlab/auto-stop-idle/on-start.sh
+++ b/jupyterlab/auto-stop-idle/on-start.sh
@@ -32,8 +32,8 @@ PYTHON_SCRIPT_PATH=$SOLUTION_DIR/sagemaker_studio_jlab_auto_stop_idle/auto_stop_
 # Issue - https://github.com/aws-samples/sagemaker-studio-apps-lifecycle-config-examples/issues/12
 # SM Distribution image 1.6 is not starting cron service by default https://github.com/aws/sagemaker-distribution/issues/354
 
-# Check if cron needs to be installed
-status="$(dpkg-query -W --showformat='${db:Status-Status}' "cron" 2>&1)"
+# Check if cron needs to be installed  ## Handle scenario where script exiting("set -eux") due to non-zero return code by adding true command.
+status="$(dpkg-query -W --showformat='${db:Status-Status}' "cron" 2>&1)" || true 
 if [ ! $? = 0 ] || [ ! "$status" = installed ]; then
 	# Fixing invoke-rc.d: policy-rc.d denied execution of restart.
 	sudo /bin/bash -c "echo '#!/bin/sh
@@ -44,7 +44,8 @@ if [ ! $? = 0 ] || [ ! "$status" = installed ]; then
 	sudo apt install cron
 else
 	echo "Package cron is already installed."
-	sudo cron
+    # start/restart the service.
+	sudo service cron restart
 fi
 
 # Creating solution directory.

--- a/jupyterlab/auto-stop-idle/on-start.sh
+++ b/jupyterlab/auto-stop-idle/on-start.sh
@@ -29,13 +29,23 @@ STATE_FILE=$SOLUTION_DIR/auto_stop_idle.st
 PYTHON_PACKAGE=sagemaker_studio_jlab_auto_stop_idle-$ASI_VERSION.tar.gz
 PYTHON_SCRIPT_PATH=$SOLUTION_DIR/sagemaker_studio_jlab_auto_stop_idle/auto_stop_idle.py
 
-# Fixing invoke-rc.d: policy-rc.d denied execution of restart.
-sudo /bin/bash -c "echo '#!/bin/sh
-exit 0' > /usr/sbin/policy-rc.d"
+# Issue - https://github.com/aws-samples/sagemaker-studio-apps-lifecycle-config-examples/issues/12
+# SM Distribution image 1.6 is not starting cron service by default https://github.com/aws/sagemaker-distribution/issues/354
 
-# Installing cron.
-echo "Installing cron..."
-sudo apt install cron
+# Check if cron needs to be installed
+status="$(dpkg-query -W --showformat='${db:Status-Status}' "cron" 2>&1)"
+if [ ! $? = 0 ] || [ ! "$status" = installed ]; then
+	# Fixing invoke-rc.d: policy-rc.d denied execution of restart.
+	sudo /bin/bash -c "echo '#!/bin/sh
+	exit 0' > /usr/sbin/policy-rc.d"
+
+	# Installing cron.
+	echo "Installing cron..."
+	sudo apt install cron
+else
+	echo "Package cron is already installed."
+	sudo cron
+fi
 
 # Creating solution directory.
 sudo mkdir -p $SOLUTION_DIR

--- a/jupyterlab/auto-stop-idle/on-start.sh
+++ b/jupyterlab/auto-stop-idle/on-start.sh
@@ -44,7 +44,7 @@ if [ ! $? = 0 ] || [ ! "$status" = installed ]; then
 	sudo apt install cron
 else
 	echo "Package cron is already installed."
-    # start/restart the service.
+        # start/restart the service.
 	sudo service cron restart
 fi
 


### PR DESCRIPTION
*Issue #, if available:*  https://github.com/aws-samples/sagemaker-studio-apps-lifecycle-config-examples/issues/12 

*Description of changes:*

1. Added fix for handling the scenario where cron service is not started by default in [SM Distribution 1.6.0](https://github.com/aws/sagemaker-distribution/issues/354)
2. Added logic for backward compatibility with SM Distribution 1.5.0 and below.

*Test results:*

Tested with JupterLab image SM Distribution 1.5.0 and SM Distribution 1.6.0. 

<img width="1208" alt="Screenshot 2024-04-21 at 19 28 49" src="https://github.com/aws-samples/sagemaker-studio-apps-lifecycle-config-examples/assets/3517075/4cafaced-89ec-44c6-9597-91f9b65495a7">
<img width="1134" alt="Screenshot 2024-04-21 at 19 28 40" src="https://github.com/aws-samples/sagemaker-studio-apps-lifecycle-config-examples/assets/3517075/515d1f21-a451-4666-803f-bec7032739e2">
<img width="1198" alt="Screenshot 2024-04-21 at 19 28 56" src="https://github.com/aws-samples/sagemaker-studio-apps-lifecycle-config-examples/assets/3517075/58142a4d-790a-4366-ba86-449e6538f1a4">
<img width="1182" alt="Screenshot 2024-04-21 at 19 28 19" src="https://github.com/aws-samples/sagemaker-studio-apps-lifecycle-config-examples/assets/3517075/9b554c8c-9d54-4177-bb1b-76e33ab57c06">
<img width="1180" alt="Screenshot 2024-04-21 at 19 28 27" src="https://github.com/aws-samples/sagemaker-studio-apps-lifecycle-config-examples/assets/3517075/fd3fbae1-1d74-42d2-84f7-a778588b2fc2">
<img width="1206" alt="Screenshot 2024-04-21 at 19 32 50" src="https://github.com/aws-samples/sagemaker-studio-apps-lifecycle-config-examples/assets/3517075/a7131338-c4f4-45c9-8ac2-120861b68540">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
